### PR TITLE
docs: add badges to README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Satori Factory
+[![NPM Version](https://img.shields.io/npm/v/satori-factory?logo=npm)](https://www.npmjs.com/package/satori-factory)
+[![test](https://github.com/yudai-nkt/satori-factory/actions/workflows/test.yml/badge.svg)](https://github.com/yudai-nkt/satori-factory/actions/workflows/test.yml)
 
 Tiny yet full-fledged JSX factory for [Satori](https://github.com/vercel/satori).
 


### PR DESCRIPTION
I wanted to add bundlephobia badge, but it yields an `EntryPointError` because this package indeed has no main entry points: https://bundlephobia.com/package/satori-factory